### PR TITLE
Fix futher problems with median-filter

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "name"          : "MagickWand",
   "license"       : "MIT",
-  "version"       : "0.1.0",
+  "version"       : "0.1.1",
   "perl"          : "6.c",
   "description"   : "ImageMagick's MagickWand API Bindings for Perl6",
   "test-depends"  : [

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ $ sudo port install ImageMagick
 
 ### Windows
 
-For 64-bit Windows, please install the [`64-bit`](https://www.imagemagick.org/download/binaries/ImageMagick-7.0.8-14-Q16-x64-dll.exe)
-DLL installer. Otherwise, use the [`32-bit`](https://www.imagemagick.org/download/binaries/ImageMagick-7.0.8-14-Q16-x86-dll.exe)
-version.
+For Windows, most people will want the standard 64-bit [`DLL installer`](https://www.imagemagick.org/script/download.php#windows).
+ If you need 32-bit or other special options, select the appropriate alternate
+installer.
 
 Also please remember to enable **"Add to PATH"** option.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ platform: x64
 
 install:
   # Install ImageMagick v7 DLLs
-  - SET MAGICK_DLL_INSTALLER=ImageMagick-7.0.8-14-Q16-x64-dll.exe
+  - SET MAGICK_DLL_INSTALLER=ImageMagick-7.0.8-22-Q16-x64-dll.exe
   - appveyor DownloadFile http://www.imagemagick.org/download/binaries/%MAGICK_DLL_INSTALLER%
   - "%MAGICK_DLL_INSTALLER% /SILENT"
   - SET MAGICK_DLL_INSTALLER=

--- a/lib/MagickWand.pm6
+++ b/lib/MagickWand.pm6
@@ -396,10 +396,9 @@ method level(Real $black_point, Real $gamma, Real $white_point) returns Bool {
     $white_point.Num ) == MagickTrue;
 }
 
-method median-filter($width = 1e0, $height = 1) returns Bool {
+method median-filter($width = 2, $height = 2) returns Bool {
   die "No wand handle defined!" unless $.handle.defined;
-  my $type = (MedianStatistic.Int)<>;
-  return MagickStatisticImage( $.handle, $type, $width.Num, $height.Int ) == MagickTrue;
+  return MagickStatisticImage( $.handle, MedianStatistic.Int, $width.Int, $height.Int ) == MagickTrue;
 }
 
 method modulate(Real $brightness, Real $saturation, Real $hue) returns Bool {

--- a/lib/MagickWand/NativeCall/Image.pm6
+++ b/lib/MagickWand/NativeCall/Image.pm6
@@ -4904,7 +4904,7 @@ the neighborhood of the specified width and height.
 sub MagickStatisticImage(
    Pointer $wand,
    uint32 $type,
-   num64 $width,
+   uint32 $width,
    uint32 $height
 )
 returns uint32 


### PR DESCRIPTION
Turns out that the underlying C library was expecting an Int for the width parameter and was getting a Num and was causing sporadic failures. After changing it to an Int, tested over 100 times with no failures.  