### PR TITLE
Add new library version for Linux

### DIFF
--- a/lib/MagickWand/NativeCall/Common.pm6
+++ b/lib/MagickWand/NativeCall/Common.pm6
@@ -21,6 +21,8 @@ sub library is export {
     return sprintf("lib%s.so.5", LIB);
   } elsif library-exists("libMagickWand-6.Q16.so") {
     return "libMagickWand-6.Q16.so";
+  } elsif library-exists("libMagickWand-7.Q16.so") {
+    return "libMagickWand-7.Q16.so";
   }
 
   # Fallback


### PR DESCRIPTION
Distros with newer software have version 7 of ImageMagick and are unable to use this module. This fixes that.